### PR TITLE
Correct undefined rdf_prefix.

### DIFF
--- a/spatialmedia/metadata_utils.py
+++ b/spatialmedia/metadata_utils.py
@@ -253,9 +253,9 @@ def parse_spherical_xml(contents, console):
             index = contents.find("<rdf:SphericalVideo")
             if index != -1:
                 index += len("<rdf:SphericalVideo")
-                contents = contents[:index] + rdf_prefix + contents[index:]
+                contents = contents[:index] + RDF_PREFIX + contents[index:]
             parsed_xml = xml.etree.ElementTree.XML(contents)
-            console("\t\tWarning missing rdf prefix:", rdf_prefix)
+            console("\t\tWarning missing rdf prefix:", RDF_PREFIX)
         except xml.etree.ElementTree.ParseError as e:
             console("\t\tParser Error on XML")
             console(e)


### PR DESCRIPTION
When I run "python spatialmedia /path/to/mp4", I get "NameError: global name 'rdf_prefix' is not defined".  Looks like a typo.