### PR TITLE
Fixed "failed to execute script gui" error when running under PyInstaller

### DIFF
--- a/spatialmedia/gui.py
+++ b/spatialmedia/gui.py
@@ -28,11 +28,8 @@ import tkFileDialog
 try:
     from Tkinter import *
 except ImportError:
-    try:
-        from tkinter import *
-    except ImportError:
-        print("Tkinter library is not available.")
-        exit(0)
+    print("Tkinter library is not available.")
+    exit(0)
 
 path = os.path.dirname(sys.modules[__name__].__file__)
 path = os.path.join(path, '..')


### PR DESCRIPTION
Fixes https://github.com/google/spatial-media/issues/100

PyInstaller looks for import statements to determine the script's dependencies. The two Tkinter imports with different capitalization ('Tkinter' and 'tkinter') seemed to confuse the latest version of PyInstaller, and it wasn't including Tkinter in the packaged binary at all, even with --hidden-import Tkinter. The lowercase "tkinter" fallback import is for Python 3 compatibility, and since the script can't currently run under Python 3 for various other reasons, I removed the import. PyInstaller binaries now work again.