### PR TITLE
Explicitly encode to UTF-8 when writing to console.

### DIFF
--- a/spatialmedia/gui.py
+++ b/spatialmedia/gui.py
@@ -44,7 +44,7 @@ class Console(object):
         self.log = []
 
     def append(self, text):
-        print text
+        print(text.encode('utf-8'))
         self.log.append(text)
 
 


### PR DESCRIPTION
This hopefully fixes https://github.com/google/spatial-media/issues/95. When running from the command line with "python gui.py", sys.stdout.encoding is "UTF-8", and printing Unicode strings to the console works. However, when running the PyInstaller binary, the console is redirected somewhere, sys.stdout.encoding is None, and print() blows up if the string contains any non-ASCII characters. By explicitly encoding the string passed to print() as UTF-8, it shouldn't matter what encoding sys.stdout is using.