### PR TITLE
Fix typo that placed padding outside the vertex list loop.

### DIFF
--- a/docs/spherical-video-v2-rfc.md
+++ b/docs/spherical-video-v2-rfc.md
@@ -336,8 +336,8 @@ aligned(8) class Mesh Box(‘mesh’) {
       for (j = 0; j < index_count; j++) {
         unsigned int(vcsb) index_as_delta;
       }
+      const unsigned int(1) padding[];
     }
-    const unsigned int(1) padding[];
 }
 ```
 


### PR DESCRIPTION
This change fixes a transcription typo in the original pull request. The padding field is supposed to be inside the vertex list loop, but I accidentally placed it outside.