### PR TITLE
fix misleading FullBox parameters

### DIFF
--- a/docs/spherical-video-v2-rfc.md
+++ b/docs/spherical-video-v2-rfc.md
@@ -154,7 +154,7 @@ ProjectionDataBox in a given `proj` box.
 
 ##### Syntax
 ```
-aligned(8) class ProjectionDataBox(unsigned int(32) proj_type, unsigned int(32) version, unsigned int(32) flags)
+aligned(8) class ProjectionDataBox(unsigned int(32) proj_type, unsigned int(8)version, unsigned int(24) flags)
     extends FullBox(proj_type, version, flags) {
 }
 ```


### PR DESCRIPTION
FullBox as defined by ISO14496-12 has 8+24bits for versioning
and flags. Passing both 32bits integers for those params is
misleading and will anyway be truncated.