### PR TITLE
Works with Python 3.x (trying this again)

### DIFF
--- a/spatialmedia/gui.py
+++ b/spatialmedia/gui.py
@@ -108,7 +108,7 @@ class Application(Frame):
 
         if audio_metadata:
             self.var_spatial_audio.set(1)
-            print audio_metadata.get_metadata_string()
+            print(audio_metadata.get_metadata_string())
 
         self.update_state()
 

--- a/spatialmedia/metadata_utils.py
+++ b/spatialmedia/metadata_utils.py
@@ -190,7 +190,7 @@ def mpeg4_add_spatial_audio(mpeg4_file, in_fh, audio_metadata, console):
                         continue
                     position = mdia_sub_element.content_start() + 8
                     in_fh.seek(position)
-                    if str(in_fh.read(4),"utf-8") == mpeg.constants.TAG_SOUN:
+                    if str(in_fh.read(4)) == mpeg.constants.TAG_SOUN:
                         return inject_spatial_audio_atom(
                             in_fh, sub_element, audio_metadata, console)
     return True
@@ -632,6 +632,6 @@ def get_num_audio_tracks(mpeg4_file, in_fh):
                         continue
                     position = mdia_sub_element.content_start() + 8
                     in_fh.seek(position)
-                    if (str(in_fh.read(4),"utf-8") == mpeg.constants.TAG_SOUN):
+                    if (str(in_fh.read(4)) == mpeg.constants.TAG_SOUN):
                         num_audio_tracks += 1
     return num_audio_tracks

--- a/spatialmedia/metadata_utils.py
+++ b/spatialmedia/metadata_utils.py
@@ -19,18 +19,19 @@
 
 import os
 import re
-import StringIO
+from io import StringIO
+import io
 import struct
 import traceback
 import xml.etree
 import xml.etree.ElementTree
+import uuid
 
 from spatialmedia import mpeg
 
 MPEG_FILE_EXTENSIONS = [".mp4", ".mov"]
 
-SPHERICAL_UUID_ID = (
-    "\xff\xcc\x82\x63\xf8\x55\x4a\x93\x88\x14\x58\x7a\x02\x52\x1f\xdd")
+SPHERICAL_UUID_ID = b"\xff\xcc\x82\x63\xf8\x55\x4a\x93\x88\x14\x58\x7a\x02\x52\x1f\xdd"
 
 # XML contents.
 RDF_PREFIX = " xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\" "
@@ -129,7 +130,7 @@ def spherical_uuid(metadata):
     uuid_leaf.header_size = 8
     uuid_leaf.content_size = 0
 
-    uuid_leaf.contents = SPHERICAL_UUID_ID + metadata
+    uuid_leaf.contents = SPHERICAL_UUID_ID + str.encode(metadata)
     uuid_leaf.content_size = len(uuid_leaf.contents)
 
     return uuid_leaf
@@ -155,12 +156,13 @@ def mpeg4_add_spherical(mpeg4_file, in_fh, metadata):
                         continue
                     position = mdia_sub_element.content_start() + 8
                     in_fh.seek(position)
-                    if in_fh.read(4) == mpeg.constants.TRAK_TYPE_VIDE:
+                    if str(in_fh.read(4),"utf-8") == mpeg.constants.TRAK_TYPE_VIDE:
                         added = True
                         break
 
                 if added:
-                    if not element.add(spherical_uuid(metadata)):
+                    sph_uuid = spherical_uuid(metadata)
+                    if not element.add(sph_uuid):
                         return False
                     break
 
@@ -188,7 +190,7 @@ def mpeg4_add_spatial_audio(mpeg4_file, in_fh, audio_metadata, console):
                         continue
                     position = mdia_sub_element.content_start() + 8
                     in_fh.seek(position)
-                    if in_fh.read(4) == mpeg.constants.TAG_SOUN:
+                    if str(in_fh.read(4),"utf-8") == mpeg.constants.TAG_SOUN:
                         return inject_spatial_audio_atom(
                             in_fh, sub_element, audio_metadata, console)
     return True
@@ -303,15 +305,16 @@ def parse_spherical_mpeg4(mpeg4_file, fh, console):
                         sub_element_id = sub_element.contents[:16]
                     else:
                         fh.seek(sub_element.content_start())
-                        sub_element_id = fh.read(16)
+                        sub_element_id = fh.read(16) 
 
                     if sub_element_id == SPHERICAL_UUID_ID:
                         if sub_element.contents:
                             contents = sub_element.contents[16:]
                         else:
                             contents = fh.read(sub_element.content_size - 16)
+                        contentsStr = str(contents,"utf-8")
                         metadata.video[trackName] = \
-                            parse_spherical_xml(contents, console)
+                            parse_spherical_xml(contentsStr, console)
 
             if sub_element.name == mpeg.constants.TAG_MDIA:
                 for mdia_sub_element in sub_element.contents:
@@ -432,7 +435,7 @@ def generate_spherical_xml(stereo=None, crop=None):
     if crop:
         crop_match = re.match(crop_regex, crop)
         if not crop_match:
-            print "Error: Invalid crop params: {crop}".format(crop=crop)
+            print("Error: Invalid crop params: {crop}".format(crop=crop))
             return False
         else:
             cropped_width_pixels = int(crop_match.group(1))
@@ -444,20 +447,20 @@ def generate_spherical_xml(stereo=None, crop=None):
 
             # This should never happen based on the crop regex.
             if full_width_pixels <= 0 or full_height_pixels <= 0:
-                print "Error with crop params: full pano dimensions are "\
+                print("Error with crop params: full pano dimensions are "\
                         "invalid: width = {width} height = {height}".format(
                             width=full_width_pixels,
-                            height=full_height_pixels)
+                            height=full_height_pixels))
                 return False
 
             if (cropped_width_pixels <= 0 or
                     cropped_height_pixels <= 0 or
                     cropped_width_pixels > full_width_pixels or
                     cropped_height_pixels > full_height_pixels):
-                print "Error with crop params: cropped area dimensions are "\
+                print("Error with crop params: cropped area dimensions are "\
                         "invalid: width = {width} height = {height}".format(
                             width=cropped_width_pixels,
-                            height=cropped_height_pixels)
+                            height=cropped_height_pixels))
                 return False
 
             # We are pretty restrictive and don't allow anything strange. There
@@ -470,14 +473,14 @@ def generate_spherical_xml(stereo=None, crop=None):
                     cropped_offset_top_pixels < 0 or
                     total_width > full_width_pixels or
                     total_height > full_height_pixels):
-                    print "Error with crop params: cropped area offsets are "\
+                    print("Error with crop params: cropped area offsets are "\
                             "invalid: left = {left} top = {top} "\
                             "left+cropped width: {total_width} "\
                             "top+cropped height: {total_height}".format(
                                 left=cropped_offset_left_pixels,
                                 top=cropped_offset_top_pixels,
                                 total_width=total_width,
-                                total_height=total_height)
+                                total_height=total_height))
                     return False
 
             additional_xml += SPHERICAL_XML_CONTENTS_CROP_FORMAT.format(
@@ -517,7 +520,7 @@ def get_expected_num_audio_components(ambisonics_type, ambisonics_order):
 
 def get_num_audio_channels(stsd, in_fh):
     if stsd.name != mpeg.constants.TAG_STSD:
-        print "get_num_audio_channels should be given a STSD box"
+        print("get_num_audio_channels should be given a STSD box")
         return -1
     for sample_description in stsd.contents:
         if sample_description.name == mpeg.constants.TAG_MP4A:
@@ -555,7 +558,7 @@ def get_sample_description_num_channels(sample_description, in_fh):
         audio_sample_rate = struct.unpack(">d", in_fh.read(8))[0]
         num_audio_channels = struct.unpack(">i", in_fh.read(4))[0]
     else:
-        print "Unsupported version for " + sample_description.name + " box"
+        print("Unsupported version for " + sample_description.name + " box")
         return -1
 
     in_fh.seek(p)
@@ -583,7 +586,7 @@ def get_aac_num_channels(box, in_fh):
 
         # Verify the read descriptor is an elementary stream descriptor
         if ord(descriptor_tag) != 3:  # Not an MP4 elementary stream.
-            print "Error: failed to read elementary stream descriptor."
+            print ("Error: failed to read elementary stream descriptor.")
             return -1
         get_descriptor_length(in_fh)
         in_fh.seek(3, 1)  # Seek to the decoder configuration descriptor
@@ -591,7 +594,7 @@ def get_aac_num_channels(box, in_fh):
 
         # Verify the read descriptor is a decoder config. descriptor.
         if ord(config_descriptor_tag) != 4:
-            print "Error: failed to read decoder config. descriptor."
+            print ("Error: failed to read decoder config. descriptor.")
             return -1
         get_descriptor_length(in_fh)
         in_fh.seek(13, 1) # offset to the decoder specific config descriptor.
@@ -599,7 +602,7 @@ def get_aac_num_channels(box, in_fh):
 
         # Verify the read descriptor is a decoder specific info descriptor
         if ord(decoder_specific_descriptor_tag) != 5:
-            print "Error: failed to read MP4 audio decoder specific config."
+            print ("Error: failed to read MP4 audio decoder specific config.")
             return -1
         audio_specific_descriptor_size = get_descriptor_length(in_fh)
         assert audio_specific_descriptor_size >= 2
@@ -609,7 +612,7 @@ def get_aac_num_channels(box, in_fh):
         if sampling_frequency_index == 0:
             # TODO: If the sample rate is 96kHz an additional 24 bit offset
             # value here specifies the actual sample rate.
-            print "Error: Greater than 48khz audio is currently not supported."
+            print ("Error: Greater than 48khz audio is currently not supported.")
             return -1
         channel_configuration = (int("0078", 16) & decoder_descriptor) >> 3
     in_fh.seek(p)
@@ -629,6 +632,6 @@ def get_num_audio_tracks(mpeg4_file, in_fh):
                         continue
                     position = mdia_sub_element.content_start() + 8
                     in_fh.seek(position)
-                    if (in_fh.read(4) == mpeg.constants.TAG_SOUN):
+                    if (str(in_fh.read(4),"utf-8") == mpeg.constants.TAG_SOUN):
                         num_audio_tracks += 1
     return num_audio_tracks

--- a/spatialmedia/metadata_utils.py
+++ b/spatialmedia/metadata_utils.py
@@ -156,7 +156,7 @@ def mpeg4_add_spherical(mpeg4_file, in_fh, metadata):
                         continue
                     position = mdia_sub_element.content_start() + 8
                     in_fh.seek(position)
-                    if str(in_fh.read(4)) == mpeg.constants.TRAK_TYPE_VIDE:
+                    if str(in_fh.read(4).decode("utf-8")) == mpeg.constants.TRAK_TYPE_VIDE:
                         added = True
                         break
 
@@ -190,7 +190,7 @@ def mpeg4_add_spatial_audio(mpeg4_file, in_fh, audio_metadata, console):
                         continue
                     position = mdia_sub_element.content_start() + 8
                     in_fh.seek(position)
-                    if str(in_fh.read(4)) == mpeg.constants.TAG_SOUN:
+                    if str(in_fh.read(4).decode("utf-8")) == mpeg.constants.TAG_SOUN:
                         return inject_spatial_audio_atom(
                             in_fh, sub_element, audio_metadata, console)
     return True
@@ -312,7 +312,7 @@ def parse_spherical_mpeg4(mpeg4_file, fh, console):
                             contents = sub_element.contents[16:]
                         else:
                             contents = fh.read(sub_element.content_size - 16)
-                        contentsStr = str(contents)
+                        contentsStr = str(contents.decode("utf-8"))
                         metadata.video[trackName] = \
                             parse_spherical_xml(contentsStr, console)
 
@@ -632,6 +632,6 @@ def get_num_audio_tracks(mpeg4_file, in_fh):
                         continue
                     position = mdia_sub_element.content_start() + 8
                     in_fh.seek(position)
-                    if (str(in_fh.read(4)) == mpeg.constants.TAG_SOUN):
+                    if (str(in_fh.read(4).decode("utf-8")) == mpeg.constants.TAG_SOUN):
                         num_audio_tracks += 1
     return num_audio_tracks

--- a/spatialmedia/metadata_utils.py
+++ b/spatialmedia/metadata_utils.py
@@ -156,7 +156,7 @@ def mpeg4_add_spherical(mpeg4_file, in_fh, metadata):
                         continue
                     position = mdia_sub_element.content_start() + 8
                     in_fh.seek(position)
-                    if str(in_fh.read(4),"utf-8") == mpeg.constants.TRAK_TYPE_VIDE:
+                    if str(in_fh.read(4)) == mpeg.constants.TRAK_TYPE_VIDE:
                         added = True
                         break
 
@@ -312,7 +312,7 @@ def parse_spherical_mpeg4(mpeg4_file, fh, console):
                             contents = sub_element.contents[16:]
                         else:
                             contents = fh.read(sub_element.content_size - 16)
-                        contentsStr = str(contents,"utf-8")
+                        contentsStr = str(contents)
                         metadata.video[trackName] = \
                             parse_spherical_xml(contentsStr, console)
 

--- a/spatialmedia/mpeg/box.py
+++ b/spatialmedia/mpeg/box.py
@@ -42,7 +42,7 @@ def load(fh, position, end):
     fh.seek(position)
     header_size = 8
     size = struct.unpack(">I", fh.read(4))[0]
-    name = str(fh.read(4))
+    name = str(fh.read(4).decode("utf-8"))
 
     if size == 1:
         size = struct.unpack(">Q", fh.read(8))[0]

--- a/spatialmedia/mpeg/box.py
+++ b/spatialmedia/mpeg/box.py
@@ -42,7 +42,7 @@ def load(fh, position, end):
     fh.seek(position)
     header_size = 8
     size = struct.unpack(">I", fh.read(4))[0]
-    name = str(fh.read(4),"utf-8")
+    name = str(fh.read(4))
 
     if size == 1:
         size = struct.unpack(">Q", fh.read(8))[0]

--- a/spatialmedia/mpeg/box.py
+++ b/spatialmedia/mpeg/box.py
@@ -20,7 +20,8 @@
 Tool for loading mpeg4 files and manipulating atoms.
 """
 
-import StringIO
+from io import StringIO
+import io
 import struct
 
 from spatialmedia.mpeg import constants
@@ -41,18 +42,18 @@ def load(fh, position, end):
     fh.seek(position)
     header_size = 8
     size = struct.unpack(">I", fh.read(4))[0]
-    name = fh.read(4)
+    name = str(fh.read(4),"utf-8")
 
     if size == 1:
         size = struct.unpack(">Q", fh.read(8))[0]
         header_size = 16
 
     if size < 8:
-        print "Error, invalid size", size, "in", name, "at", position
+        print("Error, invalid size", size, "in", name, "at", position)
         return None
 
     if (position + size) > end:
-        print ("Error: Leaf box size exceeds bounds.")
+        print("Error: Leaf box size exceeds bounds.")
         return None
 
     new_box = Box()
@@ -88,14 +89,15 @@ class Box(object):
         """
         if self.header_size == 16:
             out_fh.write(struct.pack(">I", 1))
-            out_fh.write(self.name)
+            out_fh.write(str.encode(self.name))
             out_fh.write(struct.pack(">Q", self.size()))
         elif self.header_size == 8:
             out_fh.write(struct.pack(">I", self.size()))
-            out_fh.write(self.name)
+            out_fh.write(str.encode(self.name))
 
-        if self.content_start():
-            in_fh.seek(self.content_start())
+        content_start = self.content_start()
+        if content_start:
+            in_fh.seek(content_start)
 
         if self.name == constants.TAG_STCO:
             stco_copy(in_fh, out_fh, self, delta)
@@ -123,7 +125,7 @@ class Box(object):
         """Prints the box structure."""
         size1 = self.header_size
         size2 = self.content_size
-        print "{0} {1} [{2}, {3}]".format(indent, self.name, size1, size2)
+        print ("{0} {1} [{2}, {3}]".format(indent, self.name, size1, size2))
 
 
 def tag_copy(in_fh, out_fh, size):
@@ -174,7 +176,7 @@ def index_copy(in_fh, out_fh, box, mode, mode_length, delta=0):
         content = fh.read(mode_length)
         content = struct.unpack(mode, content)[0] + delta
         new_contents.append(struct.pack(mode, content))
-    out_fh.write("".join(new_contents))
+    out_fh.write(b"".join(new_contents))
 
 
 def stco_copy(in_fh, out_fh, box, delta=0):

--- a/spatialmedia/mpeg/container.py
+++ b/spatialmedia/mpeg/container.py
@@ -35,7 +35,7 @@ def load(fh, position, end):
     fh.seek(position)
     header_size = 8
     size = struct.unpack(">I", fh.read(4))[0]
-    name = str(fh.read(4),"utf-8")
+    name = str(fh.read(4))
     if(size+position>end):
         print("Buffer overrun!")
     is_box = name not in constants.CONTAINERS_LIST

--- a/spatialmedia/mpeg/container.py
+++ b/spatialmedia/mpeg/container.py
@@ -35,7 +35,7 @@ def load(fh, position, end):
     fh.seek(position)
     header_size = 8
     size = struct.unpack(">I", fh.read(4))[0]
-    name = str(fh.read(4))
+    name = str(fh.read(4).decode("utf-8"))
     if(size+position>end):
         print("Buffer overrun!")
     is_box = name not in constants.CONTAINERS_LIST

--- a/spatialmedia/mpeg/mpeg4_container.py
+++ b/spatialmedia/mpeg/mpeg4_container.py
@@ -42,7 +42,7 @@ def load(fh):
     contents = container.load_multiple(fh, 0, size)
 
     if not contents:
-        print "Error, failed to load .mp4 file."
+        print ("Error, failed to load .mp4 file.")
         return None
     elif len(contents) == 0:
         print ("Error, no boxes found.")
@@ -98,12 +98,12 @@ class Mpeg4Container(container.Container):
 
     def merge(self, element):
         """Mpeg4 containers do not support merging."""
-        print "Cannot merge mpeg4 files"
+        print("Cannot merge mpeg4 files")
         exit(0)
 
     def print_structure(self):
         """Print mpeg4 file structure recursively."""
-        print "mpeg4 [", self.content_size, "]"
+        print("mpeg4 [", self.content_size, "]")
 
         size = len(self.contents)
         for i in range(size):

--- a/spatialmedia/mpeg/sa3d.py
+++ b/spatialmedia/mpeg/sa3d.py
@@ -47,11 +47,11 @@ def load(fh, position=None, end=None):
     name = fh.read(4)
 
     if (name != constants.TAG_SA3D):
-        print "Error: box is not an SA3D box."
+        print("Error: box is not an SA3D box.")
         return None
 
     if (position + size > end):
-        print "Error: SA3D box size exceeds bounds."
+        print("Error: SA3D box size exceeds bounds.")
         return None
 
     new_box.content_size = size - new_box.header_size


### PR DESCRIPTION
I have upgraded the code to work with Python 3.x. I have not tested exhaustively but verified (with Python 3.5.1) that I can inject video metadata and YouTube will understand it (and read it back with the spatialaudio app). I've not tested the audio side. My last PR had a error in the byte-string conversion code, fixed in this version.