### PR TITLE
Clarify metadata_source description 

### DIFF
--- a/docs/spherical-video-v2-rfc.md
+++ b/docs/spherical-video-v2-rfc.md
@@ -91,8 +91,8 @@ aligned(8) class SphericalVideoHeader extends FullBox(‘svhd’, 0, 0) {
 
 ##### Semantics
 
-- `metadata_source` is a string identifier for the source tool of the SV3D
-metadata.
+- `metadata_source` is a null-terminated string in UTF-8 characters which
+identifies the tool used to create the SV3D metadata.
 
 #### Projection Box (proj)
 ##### Definition


### PR DESCRIPTION
This change is mainly intended to clarify that the metadata_source field is null-terminated and uses UTF-8 just like other strings in the ISOBMFF spec. The wording is intended to match the wording of similar fields in the ISOBMFF spec. 