### PR TITLE
Update semantics for projections with a mesh for each eye.

### DIFF
--- a/docs/spherical-video-v2-rfc.md
+++ b/docs/spherical-video-v2-rfc.md
@@ -52,6 +52,7 @@ aligned(8) class Stereoscopic3D extends FullBox(‘st3d’, 0, 0) {
 |   `0`   | **Monoscopic**: Indicates the video frame contains a single monoscopic view. |
 |   `1`   | **Stereoscopic Top-Bottom**: Indicates the video frame contains a stereoscopic view storing the left eye on top half of the frame and right eye at the bottom half of the frame.|
 |   `2`   | **Stereoscopic Left-Right**: Indicates the video frame contains a stereoscopic view storing the left eye on left half of the frame and right eye on the right half of the frame.|
+|   `3`   | **Stereoscopic Stereo-Mesh**: Indicates the video frame contains a stereoscopic view where the frame layout for left and right eyes are encoded in the (u,v) coordinates of two meshes. This may only be used with a mesh projection that contains a mesh for each eye. |
 
 #### Spherical Video Box (sv3d)
 ##### Definition
@@ -269,11 +270,11 @@ aligned(8) class MeshProjection ProjectionDataBox(‘mshp’, 0, 0) {
      or gzip headers or a checksum. (https://tools.ietf.org/html/rfc1951)
 
 - `meshes` contain the projection meshes for rendering.  If there is only one
-  mesh box, it represents the left eye / monocular view and the stereo layout
+  mesh box, it represents the monocular view and the stereo mode
   field expressed separately in the media container is used to determine
-  the right eye view. If the mshp box contains two mesh boxes, the first box
-  represents the left eye mesh and the second box represents the right eye
-  mesh.
+  the left and right eye view in case of stereo content. If the mshp box
+  contains two mesh boxes, the first box represents the left eye mesh and the
+  second box represents the right eye mesh.
 
 #### Mesh Box (mesh)
 ##### Definition
@@ -397,17 +398,21 @@ version number.
 * (u,v) coordinates are also expressed in an OpenGL-style texture coordinate
 system, where the lower-left corner is the origin (0,0), and the upper-right is
 (1,1).
-* (u,v) coordinates need to be adjusted based on the stereo layout of the
-stream.
-   * If the stereo layout is left-right:
+* (u,v) coordinates, encoded in this box, need to be adjusted based on the
+stereo mode of the stream before rendering.
+   * If the stereo mode is monoscopic:
+      * No (u,v) coordinate adjustments are required.
+   * If the stereo mode is left-right:
       * left u' = u * 0.5
       * right u' = u * 0.5 + 0.5
-   * If the stereo layout is top-bottom:
+   * If the stereo mode is top-bottom:
       * left v' = v * 0.5
       * right v' = v * 0.5 + 0.5
-   * No adjustment is required for mono layout or when a Mesh box is provided
-     for each eye.
-
+   * If the stereo mode is stereo-mesh:
+      * Two mesh boxes must be present in the mshp box.
+      * Unmodified (u,v) coordinates from the first mesh box are used for
+rendering the left eye, and unmodified (u,v) coordinates from the second mesh
+box are used for rendering the right eye.
 
 ### Example
 
@@ -451,6 +456,11 @@ As the V2 specification stores its metadata in a different location, it is
 possible for a file to contain both the V1 and V2 metadata. If both V1 and
 V2 metadata are contained they should contain semantically equivalent
 information, with V2 taking priority when they differ.
+
+Stereo mode is specified using the existing `StereoMode` element specified in
+the Matroska spec. Only `StereoMode` values that have the same meaning as the
+ones specified in the `st3d` box are allowed at this time. (e.g. 0 - mono,
+1- left-right, 3 - top-bottom, 15 (provisional) - stereo-mesh).
 
 #### `Projection` master element
 ##### Definition


### PR DESCRIPTION
- Replaced "stereo layout" with "stereo mode" so use a single
  term for the same concept.
- Removed language that said to ignore stereo mode if two
  meshes were present.
- Added new stereo mode to explicitly signal stereo content
  with two meshes that shouldn't have coordinate adjustments
  applied.
- Clarified that the existing StereoMode element is used to
  signal stereo mode information for WebM/Matroska