### PR TITLE
spatialmedia: Define mpeg tags as bytes objects. This maintains Pytho…

### DIFF
--- a/spatialmedia/metadata_utils.py
+++ b/spatialmedia/metadata_utils.py
@@ -154,7 +154,7 @@ def mpeg4_add_spherical(mpeg4_file, in_fh, metadata):
                         continue
                     position = mdia_sub_element.content_start() + 8
                     in_fh.seek(position)
-                    if in_fh.read(4).decode() == mpeg.constants.TRAK_TYPE_VIDE:
+                    if in_fh.read(4) == mpeg.constants.TRAK_TYPE_VIDE:
                         added = True
                         break
 
@@ -187,7 +187,7 @@ def mpeg4_add_spatial_audio(mpeg4_file, in_fh, audio_metadata, console):
                         continue
                     position = mdia_sub_element.content_start() + 8
                     in_fh.seek(position)
-                    if in_fh.read(4).decode() == mpeg.constants.TAG_SOUN:
+                    if in_fh.read(4) == mpeg.constants.TAG_SOUN:
                         return inject_spatial_audio_atom(
                             in_fh, sub_element, audio_metadata, console)
     return True

--- a/spatialmedia/mpeg/box.py
+++ b/spatialmedia/mpeg/box.py
@@ -41,7 +41,7 @@ def load(fh, position, end):
     fh.seek(position)
     header_size = 8
     size = struct.unpack(">I", fh.read(4))[0]
-    name = fh.read(4).decode()
+    name = fh.read(4)
 
     if size == 1:
         size = struct.unpack(">Q", fh.read(8))[0]
@@ -88,11 +88,11 @@ class Box(object):
         """
         if self.header_size == 16:
             out_fh.write(struct.pack(">I", 1))
-            out_fh.write(self.name.encode())
+            out_fh.write(self.name)
             out_fh.write(struct.pack(">Q", self.size()))
         elif self.header_size == 8:
             out_fh.write(struct.pack(">I", self.size()))
-            out_fh.write(self.name.encode())
+            out_fh.write(self.name)
 
         if self.content_start():
             in_fh.seek(self.content_start())

--- a/spatialmedia/mpeg/constants.py
+++ b/spatialmedia/mpeg/constants.py
@@ -17,45 +17,45 @@
 
 """MPEG-4 constants."""
 
-TRAK_TYPE_VIDE = "vide"
+TRAK_TYPE_VIDE = b"vide"
 
 # Leaf types.
-TAG_STCO = "stco"
-TAG_CO64 = "co64"
-TAG_FREE = "free"
-TAG_MDAT = "mdat"
-TAG_XML = "xml "
-TAG_HDLR = "hdlr"
-TAG_FTYP = "ftyp"
-TAG_ESDS = "esds"
-TAG_SOUN = "soun"
-TAG_SA3D = "SA3D"
+TAG_STCO = b"stco"
+TAG_CO64 = b"co64"
+TAG_FREE = b"free"
+TAG_MDAT = b"mdat"
+TAG_XML = b"xml "
+TAG_HDLR = b"hdlr"
+TAG_FTYP = b"ftyp"
+TAG_ESDS = b"esds"
+TAG_SOUN = b"soun"
+TAG_SA3D = b"SA3D"
 
 # Container types.
-TAG_MOOV = "moov"
-TAG_UDTA = "udta"
-TAG_META = "meta"
-TAG_TRAK = "trak"
-TAG_MDIA = "mdia"
-TAG_MINF = "minf"
-TAG_STBL = "stbl"
-TAG_STSD = "stsd"
-TAG_UUID = "uuid"
-TAG_WAVE = "wave"
+TAG_MOOV = b"moov"
+TAG_UDTA = b"udta"
+TAG_META = b"meta"
+TAG_TRAK = b"trak"
+TAG_MDIA = b"mdia"
+TAG_MINF = b"minf"
+TAG_STBL = b"stbl"
+TAG_STSD = b"stsd"
+TAG_UUID = b"uuid"
+TAG_WAVE = b"wave"
 
 # Sound sample descriptions.
-TAG_NONE = "NONE"
-TAG_RAW_ = "raw "
-TAG_TWOS = "twos"
-TAG_SOWT = "sowt"
-TAG_FL32 = "fl32"
-TAG_FL64 = "fl64"
-TAG_IN24 = "in24"
-TAG_IN32 = "in32"
-TAG_ULAW = "ulaw"
-TAG_ALAW = "alaw"
-TAG_LPCM = "lpcm"
-TAG_MP4A = "mp4a"
+TAG_NONE = b"NONE"
+TAG_RAW_ = b"raw "
+TAG_TWOS = b"twos"
+TAG_SOWT = b"sowt"
+TAG_FL32 = b"fl32"
+TAG_FL64 = b"fl64"
+TAG_IN24 = b"in24"
+TAG_IN32 = b"in32"
+TAG_ULAW = b"ulaw"
+TAG_ALAW = b"alaw"
+TAG_LPCM = b"lpcm"
+TAG_MP4A = b"mp4a"
 
 SOUND_SAMPLE_DESCRIPTIONS = frozenset([
     TAG_NONE,
@@ -82,4 +82,3 @@ CONTAINERS_LIST = frozenset([
     TAG_UDTA,
     TAG_WAVE,
     ]).union(SOUND_SAMPLE_DESCRIPTIONS)
-

--- a/spatialmedia/mpeg/container.py
+++ b/spatialmedia/mpeg/container.py
@@ -33,12 +33,12 @@ def load(fh, position, end):
     fh.seek(position)
     header_size = 8
     size = struct.unpack(">I", fh.read(4))[0]
-    name = fh.read(4).decode()
+    name = fh.read(4)
 
     is_box = name not in constants.CONTAINERS_LIST
     # Handle the mp4a decompressor setting (wave -> mp4a).
     if name == constants.TAG_MP4A and size == 12:
-        is_box = True 
+        is_box = True
     if is_box:
         if name == constants.TAG_SA3D:
             return sa3d.load(fh, position, end)
@@ -196,11 +196,11 @@ class Container(box.Box):
         """
         if self.header_size == 16:
             out_fh.write(struct.pack(">I", 1))
-            out_fh.write(self.name.encode())
+            out_fh.write(self.name)
             out_fh.write(struct.pack(">Q", self.size()))
         elif self.header_size == 8:
             out_fh.write(struct.pack(">I", self.size()))
-            out_fh.write(self.name.encode())
+            out_fh.write(self.name)
 
         if self.padding > 0:
             in_fh.seek(self.content_start())

--- a/spatialmedia/mpeg/mpeg4_container.py
+++ b/spatialmedia/mpeg/mpeg4_container.py
@@ -52,14 +52,14 @@ def load(fh):
     loaded_mpeg4.contents = contents
 
     for element in loaded_mpeg4.contents:
-        if (element.name == "moov"):
+        if (element.name == constants.TAG_MOOV):
             loaded_mpeg4.moov_box = element
-        if (element.name == "free"):
+        if (element.name == constants.TAG_FREE):
             loaded_mpeg4.free_box = element
-        if (element.name == "mdat"
+        if (element.name == constants.TAG_MDAT
                 and not loaded_mpeg4.first_mdat_box):
             loaded_mpeg4.first_mdat_box = element
-        if (element.name == "ftyp"):
+        if (element.name == constants.TAG_FTYP):
             loaded_mpeg4.ftyp_box = element
 
     if not loaded_mpeg4.moov_box:

--- a/spatialmedia/mpeg/sa3d.py
+++ b/spatialmedia/mpeg/sa3d.py
@@ -44,7 +44,7 @@ def load(fh, position=None, end=None):
     new_box = SA3DBox()
     new_box.position = position
     size = struct.unpack(">I", fh.read(4))[0]
-    name = fh.read(4).decode()
+    name = fh.read(4)
 
     if (name != constants.TAG_SA3D):
         print("Error: box is not an SA3D box.")
@@ -112,16 +112,16 @@ class SA3DBox(box.Box):
         return new_box
 
     def ambisonic_type_name(self):
-        return  (key for key,value in SA3DBox.ambisonic_types.items()
-                 if value==self.ambisonic_type).next()
+        return  next((key for key,value in SA3DBox.ambisonic_types.items()
+                 if value==self.ambisonic_type))
 
     def ambisonic_channel_ordering_name(self):
-        return (key for key,value in SA3DBox.ambisonic_orderings.items()
-                if value==self.ambisonic_channel_ordering).next()
+        return next((key for key,value in SA3DBox.ambisonic_orderings.items()
+                if value==self.ambisonic_channel_ordering))
 
     def ambisonic_normalization_name(self):
-        return (key for key,value in SA3DBox.ambisonic_normalizations.items()
-                if value==self.ambisonic_normalization).next()
+        return next((key for key,value in SA3DBox.ambisonic_normalizations.items()
+                if value==self.ambisonic_normalization))
 
     def print_box(self, console):
         """ Prints the contents of this spatial audio (SA3D) box to the


### PR DESCRIPTION
…n3 compatibility and fixes the handling of files with non-ASCII atom types e.g. (User data atoms like '(c)swr'). Also, add Python3 support for spatial audio metadata injection.