### PR TITLE
Update container.py to solve issue 224

### DIFF
--- a/spatialmedia/mpeg/container.py
+++ b/spatialmedia/mpeg/container.py
@@ -92,7 +92,7 @@ def load(fh, position, end):
 
 def load_multiple(fh, position=None, end=None):
     loaded = list()
-    while (position < end):
+    while (position + 4 < end):
         new_box = load(fh, position, end)
         if new_box is None:
             print("Error, failed to load box.")


### PR DESCRIPTION
This change solves an error "unpack requires a buffer of 4 bytes".
https://github.com/google/spatial-media/issues/224