### PR TITLE
Add support for v1 metadata for 3d only file, and add v2 metadata support

### DIFF
--- a/spatialmedia/__main__.py
+++ b/spatialmedia/__main__.py
@@ -48,6 +48,12 @@ def main():
       help=
       "injects spatial media metadata into the first file specified (.mp4 or "
       ".mov) and saves the result to the second file specified")
+  parser.add_argument(
+      "-2",
+      "--v2",
+      action="store_true",
+      help=
+      "Uses v2 of the video metadata spec")
   video_group = parser.add_argument_group("Spherical Video")
   video_group.add_argument("-s",
                            "--stereo",
@@ -91,10 +97,13 @@ def main():
       console("Injecting metadata requires both an input file and output file.")
       return
 
-    metadata = metadata_utils.Metadata()
-    metadata.video = metadata_utils.generate_spherical_xml(args.projection,
-                                                           args.stereo_mode,
-                                                           args.crop)
+    metadata = metadata_utils.Metadata(args.projection, args.stereo_mode)
+    if not args.v2:
+      metadata.projection = None
+      metadata.stereo_mode = None
+      metadata.video = metadata_utils.generate_spherical_xml(args.projection,
+                                                             args.stereo_mode,
+                                                             args.crop)
 
     if args.spatial_audio:
       parsed_metadata = metadata_utils.parse_metadata(args.file[0], console)
@@ -110,7 +119,7 @@ def main():
                   "spatial audio format." % (parsed_metadata.num_audio_channels))
           return
 
-    if metadata.video:
+    if metadata.video or metadata.projection or metadata.stereo_mode:
       metadata_utils.inject_metadata(args.file[0], args.file[1], metadata,
                                      console)
     else:

--- a/spatialmedia/__main__.py
+++ b/spatialmedia/__main__.py
@@ -57,6 +57,13 @@ def main():
                            choices=["none", "top-bottom", "left-right"],
                            default="none",
                            help="stereo mode (none | top-bottom | left-right)")
+  video_group.add_argument("-p",
+                           "--projection",
+                           action="store",
+                           dest="projection",
+                           choices=["none", "equirectangular"],
+                           default="equirectangular",
+                           help="projection (none | equirectangular)")
   video_group.add_argument(
       "-c",
       "--crop",
@@ -85,7 +92,8 @@ def main():
       return
 
     metadata = metadata_utils.Metadata()
-    metadata.video = metadata_utils.generate_spherical_xml(args.stereo_mode,
+    metadata.video = metadata_utils.generate_spherical_xml(args.projection,
+                                                           args.stereo_mode,
                                                            args.crop)
 
     if args.spatial_audio:

--- a/spatialmedia/metadata_utils.py
+++ b/spatialmedia/metadata_utils.py
@@ -49,6 +49,14 @@ SPHERICAL_XML_CONTENTS = \
     "</GSpherical:StitchingSoftware>"\
     "<GSpherical:ProjectionType>equirectangular</GSpherical:ProjectionType>"
 
+NOT_SPHERICAL_XML_CONTENTS = \
+    "<GSpherical:Spherical>false</GSpherical:Spherical>"\
+    "<GSpherical:Stitched>false</GSpherical:Stitched>"\
+    "<GSpherical:StitchingSoftware>"\
+    "Spherical Metadata Tool"\
+    "</GSpherical:StitchingSoftware>"\
+    "<GSpherical:ProjectionType>rectangular</GSpherical:ProjectionType>"
+
 SPHERICAL_XML_CONTENTS_TOP_BOTTOM = \
     "<GSpherical:StereoMode>top-bottom</GSpherical:StereoMode>"
 SPHERICAL_XML_CONTENTS_LEFT_RIGHT = \
@@ -175,6 +183,7 @@ def mpeg4_add_spherical(mpeg4_file, in_fh, metadata):
 
     mpeg4_file.resize()
     return True
+
 
 def mpeg4_add_spatial_audio(mpeg4_file, in_fh, audio_metadata, console):
     """Adds spatial audio metadata to the first audio track of the input
@@ -433,7 +442,7 @@ def inject_metadata(src, dest, metadata, console):
     console("Unknown file type")
 
 
-def generate_spherical_xml(stereo=None, crop=None):
+def generate_spherical_xml(projection="equiretangular", stereo=None, crop=None):
     # Configure inject xml.
     additional_xml = ""
     if stereo == "top-bottom":
@@ -499,7 +508,8 @@ def generate_spherical_xml(stereo=None, crop=None):
                 cropped_offset_left_pixels, cropped_offset_top_pixels)
 
     spherical_xml = (SPHERICAL_XML_HEADER +
-                     SPHERICAL_XML_CONTENTS +
+                     (SPHERICAL_XML_CONTENTS if projection == "equirectangular"
+                      else NOT_SPHERICAL_XML_CONTENTS) +
                      additional_xml +
                      SPHERICAL_XML_FOOTER)
     return spherical_xml

--- a/spatialmedia/mpeg/constants.py
+++ b/spatialmedia/mpeg/constants.py
@@ -29,7 +29,13 @@ TAG_HDLR = b"hdlr"
 TAG_FTYP = b"ftyp"
 TAG_ESDS = b"esds"
 TAG_SOUN = b"soun"
+TAG_VIDE = b"vide"
 TAG_SA3D = b"SA3D"
+
+TAG_PRHD = b"prhd"
+TAG_EQUI = b"equi"
+TAG_SVHD = b"svhd"
+TAG_ST3D = b"st3d"
 
 # Container types.
 TAG_MOOV = b"moov"
@@ -42,6 +48,10 @@ TAG_STBL = b"stbl"
 TAG_STSD = b"stsd"
 TAG_UUID = b"uuid"
 TAG_WAVE = b"wave"
+
+TAG_SV3D = b"sv3d"
+TAG_PROJ = b"proj"
+
 
 # Sound sample descriptions.
 TAG_NONE = b"NONE"
@@ -57,6 +67,14 @@ TAG_ALAW = b"alaw"
 TAG_LPCM = b"lpcm"
 TAG_MP4A = b"mp4a"
 TAG_OPUS = b"Opus"
+
+# Video sample descriptions.
+TAG_AVC1 = b"avc1"
+TAG_VP09 = b"vp09"
+TAG_AV01 = b"av01"
+TAV_HEV1 = b"hev1"
+TAG_DVH1 = b"dvh1"
+TAG_APCN = b"apcn"
 
 SOUND_SAMPLE_DESCRIPTIONS = frozenset([
     TAG_NONE,
@@ -74,6 +92,16 @@ SOUND_SAMPLE_DESCRIPTIONS = frozenset([
     TAG_OPUS,
     ])
 
+VIDEO_SAMPLE_DESCRIPTIONS = frozenset([
+    TAG_NONE,
+    TAG_AVC1,
+    TAG_VP09,
+    TAG_AV01,
+    TAV_HEV1,
+    TAG_DVH1,
+    TAG_APCN,
+    ])
+
 CONTAINERS_LIST = frozenset([
     TAG_MDIA,
     TAG_MINF,
@@ -83,4 +111,6 @@ CONTAINERS_LIST = frozenset([
     TAG_TRAK,
     TAG_UDTA,
     TAG_WAVE,
-    ]).union(SOUND_SAMPLE_DESCRIPTIONS)
+    TAG_SV3D,
+    TAG_PROJ
+    ]).union(SOUND_SAMPLE_DESCRIPTIONS).union(VIDEO_SAMPLE_DESCRIPTIONS)

--- a/spatialmedia/mpeg/sv3d.py
+++ b/spatialmedia/mpeg/sv3d.py
@@ -1,0 +1,211 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""MPEG SV3D box processing classes.
+
+Enables the injection of an SV3D MPEG-4. The SV3D box specification
+conforms to that outlined in docs/spatial-video-v2-rfc.md
+"""
+
+import struct
+
+from spatialmedia.mpeg import box
+from spatialmedia.mpeg import constants
+
+
+def is_supported_box_name(name):
+    """Returns true if the box name is a supported sv3d box."""
+    return (name == constants.TAG_PRHD or
+            name == constants.TAG_EQUI or
+            name == constants.TAG_ST3D)
+
+
+def load(fh, position=None, end=None):
+    """ Loads the SV3D box located at position in an mp4 file.
+
+    Args:
+      fh: file handle, input file handle.
+      position: int or None, current file position.
+
+    Returns:
+      new_box: box, SV3D box loaded from the file location or None.
+    """
+    if position is None:
+        position = fh.tell()
+
+    fh.seek(position)
+    size = struct.unpack(">I", fh.read(4))[0]
+    name = fh.read(4)
+
+    if name == constants.TAG_PRHD:
+        box = PRHDBox()
+    elif name == constants.TAG_EQUI:
+        box = EQUIBox()
+    elif name == constants.TAG_ST3D:
+        box = ST3DBox()
+    else:
+        print("Error: box is not a supported SV3D sub-box.")
+        return None
+
+    box.position = position
+    box.content_size = size - box.header_size
+    box.load_content(fh)
+    return box
+
+
+class PRHDBox(box.Box):
+    def __init__(self):
+        box.Box.__init__(self)
+        self.name = constants.TAG_PRHD
+        self.header_size = 8
+        self.pose_yaw_degrees = 0
+        self.pose_pitch_degrees = 0
+        self.pose_roll_degrees = 0
+        self.content_size = 16
+
+    @staticmethod
+    def create():
+        return PRHDBox()
+
+    def print_box(self, console):
+        """ Prints the contents of this box to console."""
+        console("\t\t\tPRHD {")
+        console("\t\t\t\tPose Yaw Degrees: %d" % self.pose_yaw_degrees)
+        console("\t\t\t\tPose Pitch Degrees: %d" % self.pose_pitch_degrees)
+        console("\t\t\t\tPose Roll Degrees: %d" % self.pose_roll_degrees)
+        console("\t\t\t}")
+
+    def get_metadata_string(self):
+        """ Outputs a concise single line proj metadata string. """
+        return ("yaw:%d, pitch:%d, roll:%d" %
+                (self.pose_yaw_degrees, self.pose_pitch_degrees, self.pose_roll_degrees))
+
+    def save(self, in_fh, out_fh, delta):
+        if (self.header_size == 16):
+            out_fh.write(struct.pack(">I", 1))
+            out_fh.write(struct.pack(">Q", self.size()))
+            out_fh.write(self.name)
+        elif(self.header_size == 8):
+            out_fh.write(struct.pack(">I", self.size()))
+            out_fh.write(self.name)
+        out_fh.write(struct.pack(">I", 0)) # Version and flags
+        out_fh.write(struct.pack(">I", self.pose_yaw_degrees))
+        out_fh.write(struct.pack(">I", self.pose_pitch_degrees))
+        out_fh.write(struct.pack(">I", self.pose_roll_degrees))
+
+    def load_content(self, in_fh):
+        in_fh.read(4) # Version and flags
+        self.pose_yaw_degress = struct.unpack(">I", in_fh.read(4))[0]
+        self.pose_pitch_degrees = struct.unpack(">I", in_fh.read(4))[0]
+        self.pose_roll_degrees = struct.unpack(">I", in_fh.read(4))[0]
+
+
+class EQUIBox(box.Box):
+    def __init__(self):
+        box.Box.__init__(self)
+        self.name = constants.TAG_EQUI
+        self.header_size = 8
+        self.bounds_top = 0
+        self.bounds_bottom = 0
+        self.bounds_left = 0
+        self.bounds_right = 0
+        self.content_size = 20
+
+    @staticmethod
+    def create():
+        return EQUIBox()
+
+    def print_box(self, console):
+        """ Prints the contents of this box to console."""
+        console("\t\t\tEQUI {")
+        console("\t\t\t\tBounds Top: %d" % self.bounds_top)
+        console("\t\t\t\tBounds Bottom: %d" % self.bounds_bottom)
+        console("\t\t\t\tBounds Left: %d" % self.bounds_left)
+        console("\t\t\t\tBounds Right: %d" % self.bounds_right)
+        console("\t\t\t}")
+
+    def get_metadata_string(self):
+        """ Outputs a concise single line proj metadata string. """
+        return ("Equi (top:%d, bottom:%d, left:%d, right:%d)"
+            % (self.bounds_top, self.bounds_bottom, self.bounds_left, self.bounds_right))
+
+    def save(self, in_fh, out_fh, delta):
+        if (self.header_size == 16):
+            out_fh.write(struct.pack(">I", 1))
+            out_fh.write(struct.pack(">Q", self.size()))
+            out_fh.write(self.name)
+        elif(self.header_size == 8):
+            out_fh.write(struct.pack(">I", self.size()))
+            out_fh.write(self.name)
+        out_fh.write(struct.pack(">I", 0)) # Version and flags
+        out_fh.write(struct.pack(">I", self.bounds_top))
+        out_fh.write(struct.pack(">I", self.bounds_bottom))
+        out_fh.write(struct.pack(">I", self.bounds_left))
+        out_fh.write(struct.pack(">I", self.bounds_right))
+
+    def load_content(self, in_fh):
+        in_fh.read(4) # Version and flags
+        self.bounds_top = struct.unpack(">I", in_fh.read(4))[0]
+        self.bounds_bottom = struct.unpack(">I", in_fh.read(4))[0]
+        self.bounds_left = struct.unpack(">I", in_fh.read(4))[0]
+        self.bounds_right = struct.unpack(">I", in_fh.read(4))[0]
+
+
+class ST3DBox(box.Box):
+    def __init__(self):
+        box.Box.__init__(self)
+        self.name = constants.TAG_ST3D
+        self.header_size = 8
+        self.stereo_mode = 0
+        self.content_size = 5
+
+    @staticmethod
+    def create():
+        return ST3DBox()
+
+    def set_stereo_mode_from_string(self, stereo_mode):
+        if stereo_mode == "mono":
+            self.stereo_mode = 0
+        elif stereo_mode == "top-bottom":
+            self.stereo_mode = 1
+        elif stereo_mode == "left-right":
+            self.stereo_mode = 2
+        else:
+            print("Error: unknown stereo mode")
+
+    def print_box(self, console):
+        """ Prints the contents of this box to console."""
+        console("\t\t\tStereo Mode: %d" % self.stereo_mode)
+
+    def get_metadata_string(self):
+        """ Outputs a concise single line stereo metadata string. """
+        return "Stereo Mode: %d" % self.stereo_mode
+
+    def save(self, in_fh, out_fh, delta):
+        if (self.header_size == 16):
+            out_fh.write(struct.pack(">I", 1))
+            out_fh.write(struct.pack(">Q", self.size()))
+            out_fh.write(self.name)
+        elif(self.header_size == 8):
+            out_fh.write(struct.pack(">I", self.size()))
+            out_fh.write(self.name)
+        out_fh.write(struct.pack(">I", 0)) # Version and flags
+        out_fh.write(struct.pack(">B", self.stereo_mode))
+
+    def load_content(self, in_fh):
+        in_fh.read(4) # Version and flags
+        self.stereo_mode = int(struct.unpack(">B", in_fh.read(1))[0])


### PR DESCRIPTION
Adding support for only setting stereo mode in v1 version of the spec (e.g., use --projection=none) to the CLI tool

Also add initial support for v2 metadata (--v2). Currently supported options:
* --stereo = {none | top-bottom | left-right}
* --projection = {none | equirectangular }