### PR TITLE
Fix SyntaxWarning

### DIFF
--- a/spatialmedia/metadata_utils.py
+++ b/spatialmedia/metadata_utils.py
@@ -112,7 +112,7 @@ SPHERICAL_TAGS = dict()
 for tag in SPHERICAL_TAGS_LIST:
     SPHERICAL_TAGS[SPHERICAL_PREFIX + tag] = tag
 
-integer_regex_group = "(\d+)"
+integer_regex_group = r"(\d+)"
 crop_regex = "^{0}$".format(":".join([integer_regex_group] * 6))
 
 MAX_SUPPORTED_AMBIX_ORDER = 1


### PR DESCRIPTION
When running the gui.py script for the first time, the user sees the following warning when the Python version is newer than 3.6:

```
D:\Users\gpuvm\Downloads\Spatial Media Metadata Injector\Spatial-Media-Metadata-Injector\spatialmedia\..\spatialmedia\metadata_utils.py:115: SyntaxWarning: invalid escape sequence '\d'
  integer_regex_group = "(\d+)"
```

This only appears on the first time, so the easiest way to recreate it is to make a new clone of the repo I think.

This PR fixes this warning by writing it as a raw string.