### PR TITLE
Fix program title not being seen on Linux

### DIFF
--- a/spatialmedia/gui.py
+++ b/spatialmedia/gui.py
@@ -357,9 +357,13 @@ def report_callback_exception(self, *args):
 def main():
     root = tk.Tk()
     root.tk.call('tk', 'scaling', 2.0)
+    root.withdraw()
+    app_window = tk.Toplevel(root, class_="Spatial Media Metadata Injector")
+    app_window.resizable(False, False)
+    app_window.protocol("WM_DELETE_WINDOW", root.destroy)
     tk.report_callback_exception = report_callback_exception
-    app = Application(master=root)
-    app.mainloop()
+    Application(master=app_window)
+    root.mainloop()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This issue is quite tricky. Searching online the "solution" mentioned is to set "\_className" parameter of the root window to the title we want. But this does not really work, as this seems to be not case sensitive so the title in the taskbar shows up as "Spatial media metadata injector" which is not exactly what we want.
I've implemented now the solution that PySimpleGUI is for example also choosing. We create a toplevel window in addition to the root window and set the "class_" parameter of the toplevel window to our desired program title. This works correctly without any compromises:
 
![Screenshot 2025-06-21 003226](https://github.com/user-attachments/assets/b4574031-d1df-4f0a-85dd-99c63cd4448a)



The application window is also set to non-resizable as this GUI has no need for this functionality.

Fixes #312