### PR TITLE
fix(metadata_utils): correct default projection='equiretangular' -> 'equirectangular'

### DIFF
--- a/spatialmedia/metadata_utils.py
+++ b/spatialmedia/metadata_utils.py
@@ -540,7 +540,7 @@ def inject_metadata(src, dest, metadata, console):
     console("Unknown file type")
 
 
-def generate_spherical_xml(projection="equiretangular", stereo=None, crop=None):
+def generate_spherical_xml(projection="equirectangular", stereo=None, crop=None):
     # Configure inject xml.
     additional_xml = ""
     if stereo == "top-bottom":


### PR DESCRIPTION
Fixes #336.

Real defect: `generate_spherical_xml()` defaulted `projection` to `"equiretangular"` (missing 'c') while line 609 does `projection == "equirectangular"` to branch. So any caller using the default actually falls off the match and produces unexpected XML.

```diff
- def generate_spherical_xml(projection="equiretangular", stereo=None, crop=None):
+ def generate_spherical_xml(projection="equirectangular", stereo=None, crop=None):
```

Kept the parameter name unchanged; only the string default value changes. Callers passing the correct `"equirectangular"` literal already worked and continue to work; callers relying on the broken default are now actually spherical.