### PR TITLE
Fix equirectangular typo in generate_spherical_xml default

### DIFF
--- a/spatialmedia/metadata_utils.py
+++ b/spatialmedia/metadata_utils.py
@@ -540,7 +540,7 @@ def inject_metadata(src, dest, metadata, console):
     console("Unknown file type")
 
 
-def generate_spherical_xml(projection="equiretangular", stereo=None, crop=None):
+def generate_spherical_xml(projection="equirectangular", stereo=None, crop=None):
     # Configure inject xml.
     additional_xml = ""
     if stereo == "top-bottom":

--- a/spatialmedia_test.py
+++ b/spatialmedia_test.py
@@ -151,6 +151,18 @@ class TestAdd(unittest.TestCase):
         self.assertTrue(contents.find('Stereo Mode: 1') >= 0)
 
 
+class TestGenerateSphericalXml(unittest.TestCase):
+    def test_default_projection_is_equirectangular(self):
+        """Default projection must match the equirectangular comparison string."""
+        xml = metadata_utils.generate_spherical_xml()
+        self.assertIn('equirectangular', xml)
+        self.assertIn('<GSpherical:Spherical>true</GSpherical:Spherical>', xml)
+
+    def test_none_projection_is_not_spherical(self):
+        xml = metadata_utils.generate_spherical_xml(projection='none')
+        self.assertNotIn('equirectangular', xml)
+        self.assertIn('<GSpherical:Spherical>false</GSpherical:Spherical>', xml)
+
 if __name__ == '__main__':
     try:
         os.mkdir('test_output')


### PR DESCRIPTION
## Summary
- Corrects the default `projection` value in `generate_spherical_xml` from `equiretangular` to `equirectangular`.
- Without this, callers that omit `projection` (GUI and docker paths) fail the equality check and inject non-spherical metadata.
- Adds unit tests covering the default and `none` projection paths.

Fixes #336

## Test plan
- [x] `python3 -m unittest spatialmedia_test.TestGenerateSphericalXml -v`
- [ ] Confirm GUI/docker inject paths now emit equirectangular spherical XML by default